### PR TITLE
Nuevos tests + clearTimeout after tests. 

### DIFF
--- a/tests/central_nuclear/barras_control/estados/eliminada.test.ts
+++ b/tests/central_nuclear/barras_control/estados/eliminada.test.ts
@@ -34,4 +34,8 @@ describe("Test de Estado Barra de Control: Eliminada", () => {
     estado = rodInstance.estaActivo();
     expect(estado).toBe(false);
   });
+
+   afterEach(() => {
+     jest.clearAllTimers();
+   });
 });

--- a/tests/central_nuclear/barras_control/estados/en_desuso.test.ts
+++ b/tests/central_nuclear/barras_control/estados/en_desuso.test.ts
@@ -29,4 +29,8 @@ describe("Test de Estado Barra de Control: EnDesuso", () => {
     let estado: boolean = rodInstance.estaActivo();
     expect(estado).toBe(false);
   });
+
+   afterEach(() => {
+     jest.clearAllTimers();
+   });
 });

--- a/tests/central_nuclear/barras_control/estados/insertada.test.ts
+++ b/tests/central_nuclear/barras_control/estados/insertada.test.ts
@@ -34,4 +34,8 @@ describe("Test de Estado Barra de Control: Insertada", () => {
     estado = rodInstance.estaActivo();
     expect(estado).toBe(true);
   });
+
+   afterEach(() => {
+     jest.clearAllTimers();
+   });
 });

--- a/tests/central_nuclear/barras_control/fabrica/fabrica_barra_cadmio.test.ts
+++ b/tests/central_nuclear/barras_control/fabrica/fabrica_barra_cadmio.test.ts
@@ -1,0 +1,16 @@
+import FabricaBarraCadmio from "../../../../src/central_nuclear/barras_control/fabrica/fabrica_barra_cadmio";
+import BarraControlCadmio from "../../../../src/central_nuclear/barras_control/barra_control_cadmio";
+
+describe("Test para la fabrica de la barra de cadmio", ()=>{
+    let instanciaFabrica: FabricaBarraCadmio;
+
+    beforeEach(()=>{
+        instanciaFabrica = new FabricaBarraCadmio();
+    })
+
+    it("Deberia retornar una barra de control de cadmio",()=> {
+       let barraControlCadmio: BarraControlCadmio;
+       barraControlCadmio = instanciaFabrica.crearBarra() 
+       expect(barraControlCadmio).toBeInstanceOf(BarraControlCadmio);
+    });
+})

--- a/tests/central_nuclear/barras_control/fabrica/selector_fabrica.test.ts
+++ b/tests/central_nuclear/barras_control/fabrica/selector_fabrica.test.ts
@@ -1,0 +1,22 @@
+import FabricaBarraCadmio from "../../../../src/central_nuclear/barras_control/fabrica/fabrica_barra_cadmio";
+import SelectorFabricaBarra from "../../../../src/central_nuclear/barras_control/fabrica/selector_fabrica";
+
+describe("Testea el selector de fabrica de barras", () => {
+  let selector: SelectorFabricaBarra;
+
+  beforeEach(() => {
+    (SelectorFabricaBarra as any)._instancia = null;
+    selector = SelectorFabricaBarra.getInstancia();
+  });
+
+  it("deberia retornar una nueva fábrica", () => {
+    const fabricaBarraCadmio = selector.getFabrica("cadmio");
+    expect(fabricaBarraCadmio).toBeInstanceOf(FabricaBarraCadmio);
+  });
+
+  it("debería retornar una excepción", () => {
+    expect(() => {
+      selector.getFabrica("unaFabricaQueNoExiste");
+    }).toThrow("No existe la fabrica");
+  });
+});

--- a/tests/central_nuclear/reactor/estados_reactor/apagado.test.ts
+++ b/tests/central_nuclear/reactor/estados_reactor/apagado.test.ts
@@ -28,6 +28,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.clearAllTimers();
 });
 
 describe("Test del estado apagado", () => {

--- a/tests/central_nuclear/reactor/estados_reactor/chernobyl.test.ts
+++ b/tests/central_nuclear/reactor/estados_reactor/chernobyl.test.ts
@@ -13,6 +13,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.clearAllTimers();
 });
 
 describe("Test del estado apagado", () => {

--- a/tests/central_nuclear/reactor/estados_reactor/critico.test.ts
+++ b/tests/central_nuclear/reactor/estados_reactor/critico.test.ts
@@ -18,6 +18,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.clearAllTimers();
 });
 
 describe("Test del estado apagado", () => {

--- a/tests/central_nuclear/reactor/estados_reactor/emergencia.test.ts
+++ b/tests/central_nuclear/reactor/estados_reactor/emergencia.test.ts
@@ -29,6 +29,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.clearAllTimers();
 });
 
 describe("Test del estado apagado", () => {

--- a/tests/central_nuclear/reactor/estados_reactor/encendiendo.test.ts
+++ b/tests/central_nuclear/reactor/estados_reactor/encendiendo.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.clearAllTimers();
 });
 
 describe("Test del estado apagado", () => {

--- a/tests/central_nuclear/reactor/estados_reactor/normal.test.ts
+++ b/tests/central_nuclear/reactor/estados_reactor/normal.test.ts
@@ -27,6 +27,7 @@ beforeEach(() => {
 
 afterEach(() => {
   jest.clearAllMocks();
+  jest.clearAllTimers();
 });
 
 describe("Test del estado normal", () => {

--- a/tests/central_nuclear/reactor/reactor.test.ts
+++ b/tests/central_nuclear/reactor/reactor.test.ts
@@ -29,6 +29,7 @@ describe("Test del reactor", () => {
 
   afterEach(() => {
     jest.clearAllMocks();
+    jest.clearAllTimers();
   });
 
   it("Debería inicializar el reactor con los valores correctos por defecto", () => {


### PR DESCRIPTION
Queda resolver que algunos tests no cortan con los timeouts al terminar, lo cual evita que Jest termine.